### PR TITLE
Using ZOOM::Options to ensure authentification is done properly

### DIFF
--- a/lib/Catmandu/Importer/Z3950.pm
+++ b/lib/Catmandu/Importer/Z3950.pm
@@ -84,15 +84,17 @@ sub _coerce_handler {
 sub _setup_connection {
   my ($self) = @_;
 
-  my $conn = ZOOM::Connection->new(
+	my $opts = ZOOM::Options->new();
+	$opts->option(databaseName => $self->databaseName);
+  $opts->option(preferredRecordSyntax => $self->preferredRecordSyntax) if $self->preferredRecordSyntax;
+  $opts->option(user => $self->user) if $self->user;
+  $opts->option(password => $self->password) if $self->password;
+
+	my $conn = ZOOM::Connection->create($opts);
+  $conn->connect(
     $self->host,
     $self->port,
-    databaseName => $self->databaseName
   );
-
-  $conn->option(preferredRecordSyntax => $self->preferredRecordSyntax) if $self->preferredRecordSyntax;
-  $conn->option(user => $self->user) if $self->user;
-  $conn->option(password => $self->password) if $self->password;
 
   return $conn;
 }


### PR DESCRIPTION
I've rewritten the body of the _setup_connection to use ZOOM::Options to handle the various options to pass to connect to a server that required authentification. 

When using the following command: `catmandu convert Z3950 --user 'Z3950' --password 'Z3950_BNF' --host z3950.bnf.fr --port 2211 --databaseName TOUT-ANA1-UTF8 --preferredRecordSyntax Unimarc  --queryType PQF --query '@attr 1=7 9782744024191' to JSON --pretty 1`, I can now see the record: `[{
   "record" : "01830cam  2200397   450 001002100000003004700021010003500068020001700103073001800120100004100138101000800179102000700187105001800194106000600212181001900218181002400237182001000261182002000271200013700291210009200428215004500520225002300565300006700588300001000655410005800665606005400723676002300777686007000800700006900870701005800939701005800997702005801055801007001113930011601183930013301299\u001eFRBNF423141140000009\u001ehttp://catalogue.bnf.fr/ark:/12148/cb42314114d\u001e  \u001fa978-2-7440-2419-1\u001fbbr.\u001fd22 EUR\u001e  \u001faFR\u001fb01102691\u001e 0\u001fa9782744024191\u001e  \u001fa20101109d2010    m  y0frey50      ba\u001e0 \u001fafre\u001e  \u001faFR\u001e  \u001fa||||z   00|y|\u001e  \u001far\u001e 0\u001f601\u001fai \u001fbxxxe  \u001e  \u001f602\u001fctxt\u001f2rdacontent\u001e 0\u001f601\u001fan\u001e  \u001f602\u001fcn\u001f2rdamedia\u001e1 \u001faPerl moderne\u001fbTexte imprimÃ©\u001ffSÃ©bastien Aperghis-Tramoni, Damien Krotkine, JÃ©rÃ´me Quelin\u001fgavec la contribution de Philippe Bruhat\u001e  \u001faParis\u001fcPearson Ã©ducation France\u001fdimpr. 2010\u001fe63-Clermont-Ferrand\u001fgImpr. la Source d'or\u001e  \u001fa1 vol. (XVIII-445 p.)\u001fccouv. ill.\u001fd19 cm\u001e| \u001faLe guide de survie\u001e  \u001faLa couv. porte en plus : \"l'essentiel des pratiques actuelles\"\u001e  \u001faIndex\u001e 0\u001f040971782\u001ftLe Guide de survie (Paris)\u001fx1955-9992\u001fd2010\u001e  \u001f312490649\u001faPerl (langage de programmation)\u001f2rameau\u001e  \u001fa005.133 (Perl)\u001fv23\u001e  \u001fa004\u001f2Cadre de classement de la Bibliographie nationale franÃ§aise\u001e |\u001f316260239\u001foISNI000000011245581X\u001faAperghis-Tramoni\u001fbSÃ©batien\u001f4070\u001e |\u001f315065226\u001foISNI0000000004954144\u001faKrotkine\u001fbDamien\u001f4070\u001e |\u001f316260247\u001foISNI0000000111592986\u001faQuelin\u001fbJÃ©rÃ´me\u001f4070\u001e |\u001f313763352\u001foISNI0000000002934318\u001faBruhat\u001fbPhilippe\u001f4205\u001e 0\u001faFR\u001fbFR-751131015\u001fc20101109\u001fgAFNOR\u001fhFRBNF423141140000009\u001f2intermrc\u001e  \u001f5FR-751131009:42314114001001\u001fa2011-5584\u001fb759999999\u001fcTolbiac - Rez de Jardin - Sciences et technique - Magasin\u001fdO\u001e  \u001f5FR-751131009:42314114002001\u001fa2011-12624\u001fb759999999\u001fcTolbiac - Haut de Jardin - Sciences et technique - Salle C - Libre accÃ¨s\u001fdN\u001e\u001d"
}]`. 

There is still some problem because the UNIMARC record is not correctly parsed, but issue #2 is fixed.